### PR TITLE
Update package info for PyPI fork

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -509,7 +509,7 @@ except pkg_resources.DistributionNotFound:
 
 setup(
     name='pybullet-svl',
-    version='3.1.6',
+    version='3.1.6.dev0',
     description=
     "Python Interface for Stanford Vision and Learning Lab's fork of the Bullet Physics SDK specialized for Robotics Simulation and Reinforcement Learning",
     long_description=

--- a/setup.py
+++ b/setup.py
@@ -513,10 +513,10 @@ setup(
     description=
     "Python Interface for Stanford Vision and Learning Lab's fork of the Bullet Physics SDK specialized for Robotics Simulation and Reinforcement Learning",
     long_description=
-    'pybullet is an easy to use Python module for physics simulation, robotics and deep reinforcement learning based on the Bullet Physics SDK. With pybullet you can load articulated bodies from URDF, SDF and other file formats. pybullet provides forward dynamics simulation, inverse dynamics computation, forward and inverse kinematics and collision detection and ray intersection queries. Aside from physics simulation, pybullet supports to rendering, with a CPU renderer and OpenGL visualization and support for virtual reality headsets.',
-    url='https://github.com/bulletphysics/bullet3',
-    author='Fei Xia, Erwin Coumans, Yunfei Bai, Jasmine Hsu',
-    author_email='fxia22@stanford.edu',
+    "Stanford Vision and Learning Lab's fork of pybullet. pybullet is an easy to use Python module for physics simulation, robotics and deep reinforcement learning based on the Bullet Physics SDK. With pybullet you can load articulated bodies from URDF, SDF and other file formats. pybullet provides forward dynamics simulation, inverse dynamics computation, forward and inverse kinematics and collision detection and ray intersection queries. Aside from physics simulation, pybullet supports to rendering, with a CPU renderer and OpenGL visualization and support for virtual reality headsets.",
+    url='https://github.com/StanfordVL/bullet3',
+    author='Erwin Coumans, Yunfei Bai, Jasmine Hsu, Fei Xia',
+    author_email='feixia@stanford.edu',
     license='zlib',
     platforms='any',
     keywords=[

--- a/setup.py
+++ b/setup.py
@@ -500,15 +500,15 @@ if 'BT_USE_EGL' in EGL_CXX_FLAGS:
   extensions.append(eglRender)
 
 setup(
-    name='pybullet',
+    name='pybullet-svl',
     version='3.1.6',
     description=
-    'Official Python Interface for the Bullet Physics SDK specialized for Robotics Simulation and Reinforcement Learning',
+    "Python Interface for Stanford Vision and Learning Lab's fork of the Bullet Physics SDK specialized for Robotics Simulation and Reinforcement Learning",
     long_description=
     'pybullet is an easy to use Python module for physics simulation, robotics and deep reinforcement learning based on the Bullet Physics SDK. With pybullet you can load articulated bodies from URDF, SDF and other file formats. pybullet provides forward dynamics simulation, inverse dynamics computation, forward and inverse kinematics and collision detection and ray intersection queries. Aside from physics simulation, pybullet supports to rendering, with a CPU renderer and OpenGL visualization and support for virtual reality headsets.',
     url='https://github.com/bulletphysics/bullet3',
-    author='Erwin Coumans, Yunfei Bai, Jasmine Hsu',
-    author_email='erwincoumans@google.com',
+    author='Fei Xia, Erwin Coumans, Yunfei Bai, Jasmine Hsu',
+    author_email='fxia22@stanford.edu',
     license='zlib',
     platforms='any',
     keywords=[

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from sys import platform as _platform
 import sys
 import glob
 import os
+import pkg_resources
 
 from distutils.core import setup
 from distutils.extension import Extension
@@ -498,6 +499,13 @@ if 'BT_USE_EGL' in EGL_CXX_FLAGS:
       ])
 
   extensions.append(eglRender)
+
+# Check that a non-SVL pybullet is not installed
+try:
+  pkg_resources.get_distribution("pybullet")
+  raise ValueError("Please uninstall any other pybullet distributions from your environment prior to installing this fork.")
+except pkg_resources.DistributionNotFound:
+  pass
 
 setup(
     name='pybullet-svl',


### PR DESCRIPTION
This includes a package rename & also a safeguard to prevent both this and `pybullet` from being installed. The module is accessible by doing `import pybullet` still.

You can push this to PyPI when ready.